### PR TITLE
Add version info to images built from master

### DIFF
--- a/python2/Dockerfile
+++ b/python2/Dockerfile
@@ -45,6 +45,7 @@ RUN     apk add --no-cache --virtual .build-deps \
         git archive \
             --worktree-attributes \
             HEAD |tar -v -C $ZIPLINE_SRC -x && \
+        ln -v -s $ZIPLINE_SRC /src/zipline && \
         cd $ZIPLINE_SRC && \
         pip install \
             --no-cache-dir \
@@ -80,7 +81,7 @@ RUN     apk add --no-cache --virtual .build-deps \
 
 USER    $ZIPLINE_USER
 
-WORKDIR /src
+WORKDIR /src/zipline
 
 VOLUME  $ZIPLINE_ROOT
 

--- a/python2/Dockerfile
+++ b/python2/Dockerfile
@@ -52,7 +52,7 @@ RUN     apk add --no-cache --virtual .build-deps \
             --no-compile \
             --editable \
             . && \
-        rm -v -rf \
+        rm -rf \
             build \
             /src/zipline.git && \
         addgroup $ZIPLINE_GROUP && \

--- a/python2/Dockerfile
+++ b/python2/Dockerfile
@@ -19,6 +19,7 @@ RUN     apk add --no-cache --virtual .build-deps \
             ca-certificates \
             curl \
             gfortran \
+            git \
             openblas-dev \
             py-pip \
             python2-dev && \
@@ -26,24 +27,33 @@ RUN     apk add --no-cache --virtual .build-deps \
             --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
             hdf5-dev && \
         ln -v -s /usr/include/locale.h /usr/include/xlocale.h && \
-        mkdir -v /src && \
-        curl -s -L -o /src/zipline.tar.gz \
-            https://github.com/quantopian/zipline/archive/$ZIPLINE_REF.tar.gz && \
-        tar -C /src/ -vxzf /src/zipline.tar.gz && \
-        rm -v /src/zipline.tar.gz && \
-        mv -v /src/zipline-$ZIPLINE_REF /src/zipline && \
+        git clone \
+            --single-branch \
+            --branch $ZIPLINE_REF \
+            https://github.com/quantopian/zipline.git /src/zipline.git && \
+        cd /src/zipline.git && \
         export NPY_NUM_BUILD_JOBS=$(getconf _NPROCESSORS_ONLN) && \
         pip install \
             --no-cache-dir \
             --no-compile \
-            -r /src/zipline/etc/requirements.txt && \
+            -r etc/requirements.txt && \
+        ZIPLINE_SRC=/src/zipline-$(python3 setup.py version |grep ^Version |awk '{print $2}') && \
+        mkdir -v \
+            $ZIPLINE_SRC && \
+        rm -v \
+            .gitattributes && \
+        git archive \
+            --worktree-attributes \
+            HEAD |tar -v -C $ZIPLINE_SRC -x && \
+        cd $ZIPLINE_SRC && \
         pip install \
             --no-cache-dir \
             --no-compile \
             --editable \
-            /src/zipline && \
-        rm -vrf \
-            /src/zipline/build && \
+            . && \
+        rm -v -rf \
+            build \
+            /src/zipline.git && \
         addgroup $ZIPLINE_GROUP && \
         adduser \
             -D \
@@ -70,7 +80,7 @@ RUN     apk add --no-cache --virtual .build-deps \
 
 USER    $ZIPLINE_USER
 
-WORKDIR /src/zipline
+WORKDIR /src
 
 VOLUME  $ZIPLINE_ROOT
 

--- a/python2/Dockerfile.dev
+++ b/python2/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN     apk add --no-cache --virtual .build-deps \
             --no-compile \
             -r etc/requirements_blaze.txt \
             -r etc/requirements_dev.txt && \
-        rm -vrf \
+        rm -rf \
             src && \
         apk del --no-cache \
             .build-deps && \

--- a/python2/Dockerfile.talib
+++ b/python2/Dockerfile.talib
@@ -21,7 +21,7 @@ RUN     apk add --no-cache --virtual .build-deps \
         (make -j$(getconf _NPROCESSORS_ONLN) || make ) && \
         make install && \
         cd .. && \
-        rm -vr ta-lib ta-lib-src.tar.gz && \
+        rm -r ta-lib ta-lib-src.tar.gz && \
         pip install \
             --no-cache-dir \
             --no-compile \

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -19,30 +19,40 @@ RUN     apk add --no-cache --virtual .build-deps \
             ca-certificates \
             curl \
             gfortran \
+            git \
             openblas-dev \
             python3-dev && \
         apk add --no-cache --virtual .hdf5-dev \
             --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
             hdf5-dev && \
         ln -v -s /usr/include/locale.h /usr/include/xlocale.h && \
-        mkdir -v /src && \
-        curl -s -L -o /src/zipline.tar.gz \
-            https://github.com/quantopian/zipline/archive/$ZIPLINE_REF.tar.gz && \
-        tar -C /src/ -vxzf /src/zipline.tar.gz && \
-        rm -v /src/zipline.tar.gz && \
-        mv -v /src/zipline-$ZIPLINE_REF /src/zipline && \
+        git clone \
+            --single-branch \
+            --branch $ZIPLINE_REF \
+            https://github.com/quantopian/zipline.git /src/zipline.git && \
+        cd /src/zipline.git && \
         export NPY_NUM_BUILD_JOBS=$(getconf _NPROCESSORS_ONLN) && \
         pip3 install \
             --no-cache-dir \
             --no-compile \
-            -r /src/zipline/etc/requirements.txt && \
+            -r etc/requirements.txt && \
+        ZIPLINE_SRC=/src/zipline-$(python3 setup.py version |grep ^Version |awk '{print $2}') && \
+        mkdir -v \
+            $ZIPLINE_SRC && \
+        rm -v \
+            .gitattributes && \
+        git archive \
+            --worktree-attributes \
+            HEAD |tar -v -C $ZIPLINE_SRC -x && \
+        cd $ZIPLINE_SRC && \
         pip3 install \ 
             --no-cache-dir \
             --no-compile \
             --editable \
-            /src/zipline && \
-        rm -vrf \
-            /src/zipline/build && \
+            . && \
+        rm -v -rf \
+            build \
+            /src/zipline.git && \
         addgroup $ZIPLINE_GROUP && \
         adduser \
             -D \
@@ -68,7 +78,7 @@ RUN     apk add --no-cache --virtual .build-deps \
 
 USER    $ZIPLINE_USER
 
-WORKDIR /src/zipline
+WORKDIR /src
 
 VOLUME  $ZIPLINE_ROOT
 

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -51,7 +51,7 @@ RUN     apk add --no-cache --virtual .build-deps \
             --no-compile \
             --editable \
             . && \
-        rm -v -rf \
+        rm -rf \
             build \
             /src/zipline.git && \
         addgroup $ZIPLINE_GROUP && \

--- a/python3/Dockerfile
+++ b/python3/Dockerfile
@@ -44,6 +44,7 @@ RUN     apk add --no-cache --virtual .build-deps \
         git archive \
             --worktree-attributes \
             HEAD |tar -v -C $ZIPLINE_SRC -x && \
+        ln -v -s $ZIPLINE_SRC /src/zipline && \
         cd $ZIPLINE_SRC && \
         pip3 install \ 
             --no-cache-dir \
@@ -78,7 +79,7 @@ RUN     apk add --no-cache --virtual .build-deps \
 
 USER    $ZIPLINE_USER
 
-WORKDIR /src
+WORKDIR /src/zipline
 
 VOLUME  $ZIPLINE_ROOT
 

--- a/python3/Dockerfile.dev
+++ b/python3/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN     apk add --no-cache --virtual .build-deps \
             --no-compile \
             -r etc/requirements_blaze.txt \
             -r etc/requirements_dev.txt && \
-        rm -vrf \
+        rm -rf \
             src && \
         apk del --no-cache \
             .build-deps && \

--- a/python3/Dockerfile.talib
+++ b/python3/Dockerfile.talib
@@ -20,7 +20,7 @@ RUN     apk add --no-cache --virtual .build-deps \
         (make -j$(getconf _NPROCESSORS_ONLN) || make ) && \
         make install && \
         cd .. && \
-        rm -vr ta-lib ta-lib-src.tar.gz && \
+        rm -r ta-lib ta-lib-src.tar.gz && \
         pip3 install \
             --no-cache-dir \
             --no-compile \


### PR DESCRIPTION
This change helps the Versioneer to detect the commit used to build an image from the master ref.